### PR TITLE
Fix setup.py to install via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,7 @@ import os
 
 from setuptools import setup, find_packages
 
-ROOT = os.path.abspath(os.path.dirname(__file__))
-
-with open(os.path.join(ROOT, 'VERSION')) as f:
-    VERSION = f.read().strip()
+VERSION = '0.1.0'
 
 setup(
     name='django-premailer',


### PR DESCRIPTION
The current installation via pip was not working.

Here is a simple solution (simply change the version variable on new release instead of trying to guess the correct version).