### PR TITLE
Update tox and travis with latest supported versions of Python, Django and premailer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,50 +1,47 @@
+dist: xenial
+sudo: true
+
 language: python
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
+  - "pypy"
+  - "pypy3"
+
+env:
+  - DJANGO=1.11
+  - DJANGO=2.1
+  - DJANGO=2.2
+  - DJANGO=master
+
 matrix:
-  include:
-    - python: 2.7
-      env: TOXENV=py27-django16
-    - python: 2.7
-      env: TOXENV=py27-django17
-    - python: 2.7
-      env: TOXENV=py27-django18
-    - python: 3.3
-      env: TOXENV=py33-django16
-    - python: 3.3
-      env: TOXENV=py33-django17
-    - python: 3.3
-      env: TOXENV=py33-django18
-    - python: 3.4
-      env: TOXENV=py34-django16
-    - python: 3.4
-      env: TOXENV=py34-django17
-    - python: 3.4
-      env: TOXENV=py34-django18
-    - python: 3.5
-      env: TOXENV=py35-django18
-    - python: 3.5
-      env: TOXENV=py35-django19
-    - python: pypy
-      env: TOXENV=pypy-django16
-    - python: pypy
-      env: TOXENV=pypy-django17
-    - python: pypy
-      env: TOXENV=pypy-django18
-    - python: pypy
-      env: TOXENV=pypy-django19
-    - python: pypy3
-      env: TOXENV=pypy3-django16
-    - python: pypy3
-      env: TOXENV=pypy3-django17
-    - python: pypy3
-      env: TOXENV=pypy3-django18
-    - python: pypy3
-      env: TOXENV=pypy3-django19
+  exclude:
+    # Python/Django combinations that aren't officially supported
+    - { env: DJANGO=1.11, python: 3.7 }
+    - { env: DJANGO=2.1, python: 2.7 }
+    - { env: DJANGO=2.1, python: "pypy" }
+    - { env: DJANGO=2.1, python: 3.4 }
+    - { env: DJANGO=2.2, python: 2.7 }
+    - { env: DJANGO=2.2, python: "pypy" }
+    - { env: DJANGO=2.2, python: 3.4 }
+    - { env: DJANGO=master, python: 2.7 }
+    - { env: DJANGO=master, python: "pypy" }
+    - { env: DJANGO=master, python: 3.4 }
+    - { env: DJANGO=master, python: 3.5 }
+
   allow_failures:
-    - python: pypy3
+    - env: DJANGO=master
+
 install:
-  - pip install tox
-  - pip install codecov
+  - pip install tox-travis
+
 script:
   - tox
+
 after_success:
+  - pip install codecov
+  - codecov -e TOXENV,DJANGO
   - bash <(curl -s https://codecov.io/bash)

--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,12 @@ Django template tag that turns CSS blocks into style attributes using premailer_
     :target: https://travis-ci.org/alexhayes/django-premailer
     :alt: Build Status
 
-.. image:: https://landscape.io/github/alexhayes/django-premailer/master/landscape.png
+.. image:: https://landscape.io/github/alexhayes/django-premailer/master/landscape.svg?style=flat
     :target: https://landscape.io/github/alexhayes/django-premailer/
     :alt: Code Health
 
-.. image:: https://codecov.io/github/alexhayes/django-premailer/coverage.svg?branch=master
-    :target: https://codecov.io/github/alexhayes/django-premailer?branch=master
+.. image:: https://codecov.io/gh/alexhayes/django-premailer/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/alexhayes/django-premailer
     :alt: Code Coverage
 
 .. image:: https://readthedocs.org/projects/django-premailer/badge/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-premailer==3.0.0
+premailer>=3.0.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,1 +1,1 @@
-premailer==3.0.0
+premailer>=3.0.0

--- a/requirements/rtd.txt
+++ b/requirements/rtd.txt
@@ -1,2 +1,2 @@
 -r default.txt
-Django==1.9
+Django>=2.2,<3.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,1 +1,2 @@
+-r default.txt
 coverage

--- a/scripts/removepyc.sh
+++ b/scripts/removepyc.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-(cd "${1:-.}";
-        find . -name "*.pyc" | xargs rm -- 2>/dev/null) || echo "ok"

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,9 @@ extra = {}
 classes = """
     Development Status :: 4 - Beta
     Framework :: Django
-    Framework :: Django :: 1.6
-    Framework :: Django :: 1.7
-    Framework :: Django :: 1.8
-    Framework :: Django :: 1.9
+    Framework :: Django :: 1.11
+    Framework :: Django :: 2.1
+    Framework :: Django :: 2.2
     License :: OSI Approved :: MIT License
     Topic :: Communications
     Topic :: Internet :: WWW/HTTP
@@ -42,9 +41,10 @@ classes = """
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,33 @@
 [tox]
 envlist =
-    py{27,33,34,py,py3}-django{16,17,18}
-    py{35}-django{18,19}
+    py{27,34,35,36}-django111
+    py{35,36,37}-django{21,22}
+    py{36,37}-djangomaster
+    clean
+
+[travis:env]
+DJANGO =
+    1.11: django111
+    2.0: django20
+    2.1: django21
+    2.2: django22
+    master: djangomaster
 
 [testenv]
-sitepackages = False
-commands = {toxinidir}/scripts/removepyc.sh {toxinidir}
-           {toxinidir}/manage.py test
-setenv = C_DEBUG_TEST = 1
-recreate = False
+commands = {toxinidir}/manage.py test
+           
 deps =
-    -r{toxinidir}/requirements/default.txt
     -r{toxinidir}/requirements/test.txt
-    django19: Django>=1.9,<1.10
-    django18: Django>=1.8,<1.9
-    django17: Django>=1.7,<1.8
-    django16: Django>=1.6,<1.7
+    django111: Django>=1.11,<2.0
+    django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<3.0
+    djangomaster: https://github.com/django/django/archive/master.tar.gz
+
+[testenv:clean]
+commands =
+    ; rm -rf .tox/ behave_django.egg-info/ build/ dist/ docs/_build/
+    find {toxinidir} -type f -name '*.pyc' -delete
+    find {toxinidir} -type d -name '__pycache__' -delete
+whitelist_externals =
+    find
+    rm


### PR DESCRIPTION
Tox / Travis
- Remove Python 3.3
- Add Python 3.6 and 3.7
- Test only LTS version of Django 1.x which is 1.11

Also:
- Update setup.py
- Remove pinned version of premailer version and change to >=3.0.0 as it's now up to 3.4.1
